### PR TITLE
Update slackbot.tcl

### DIFF
--- a/slackbot.tcl
+++ b/slackbot.tcl
@@ -35,7 +35,7 @@ proc pub_slackpush {nick mask hand channel args} {
     # set the JSON payload and push it to slack
     set payload [
         ::json::write object \
-        text [json::write string $msg] \
+        text [json::write string "$nick: $msg"] \
         username [json::write string $nick] \
         channel [json::write string [::slack::channel::ircToSlack $channel]] \
         unfurl_links [json::write string $::slack::webhook::unfurl_links]

--- a/slackbot.tcl
+++ b/slackbot.tcl
@@ -35,7 +35,7 @@ proc pub_slackpush {nick mask hand channel args} {
     # set the JSON payload and push it to slack
     set payload [
         ::json::write object \
-        text [json::write string "$nick: $msg"] \
+        text [json::write string "<$nick> $msg"] \
         username [json::write string $nick] \
         channel [json::write string [::slack::channel::ircToSlack $channel]] \
         unfurl_links [json::write string $::slack::webhook::unfurl_links]


### PR DESCRIPTION
When using `Incoming-WebHook` inside a custom app, `username` is ignored, thus `$nick` isn't passed, just the msg text is. This change creates `$msg` with `$nick` in the old style `$nick: $msg` format.

`$channel` is also ignored but not critical since the app you create is installed to the slack channel and the webhook url routes payload to that channel.